### PR TITLE
Update requirements.txt - add matplotlib

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,5 @@ h5py
 requests
 feather-format
 biopython
+matplotlib
 click


### PR DESCRIPTION
I tried to run your program and the first error that came up was that it couldn't find the module matplotlib. I then noticed it wasn't in the requirements file.

**If merged, this PR will:**
- add matplotlib to requirements.txt